### PR TITLE
Adds entry proc macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2021"
 
 [dependencies]
 bitflags = "2.4"
+zfi-macros = { path = "./zfi-macros" }
+
+[workspace]
+members = ["zfi-macros"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub use self::status::*;
 pub use self::string::*;
 pub use self::system::*;
 pub use self::time::*;
+pub use zfi_macros::main;
 
 use alloc::boxed::Box;
 use core::cell::RefCell;

--- a/zfi-macros/Cargo.toml
+++ b/zfi-macros/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "zfi-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/zfi-macros/src/lib.rs
+++ b/zfi-macros/src/lib.rs
@@ -1,0 +1,18 @@
+use proc_macro::TokenStream;
+
+/// Define the entry of efi program, automatically import alloc crate and generate global_allocator
+#[proc_macro_attribute]
+pub fn main(_: TokenStream, main: TokenStream) -> TokenStream {
+    let main = syn::parse_macro_input!(main as syn::ItemFn);
+    let fn_name = &main.sig.ident;
+    quote::quote! {
+        extern crate alloc;
+        #[global_allocator] static ALLOCATOR: ::zfi::PoolAllocator = ::zfi::PoolAllocator;
+        #[no_mangle] extern "efiapi" fn efi_main(image: &'static ::zfi::Image, st: &'static ::zfi::SystemTable) -> ::zfi::Status {
+            unsafe { ::zfi::init(image, st, Some(|| { ::alloc::boxed::Box::new(::zfi::DebugFile::next_to_image("log").unwrap()) })) };
+            let start: fn(image: &'static ::zfi::Image, st: &'static ::zfi::SystemTable) -> ::zfi::Status = #fn_name;
+            start(image, st)
+        }
+        #main
+    }.into()
+}


### PR DESCRIPTION
refer to https://github.com/ultimicro/zfi/issues/1

I don't quite understand how a crate with this structure is published to the crate, but it does work for now.
A simple example:
```
#![no_std]
#![no_main]

use zfi::*;

#[zfi::main]
fn main(_image: &'static Image, _st: &'static SystemTable) -> Status {
     println!("Hello, world!");
     Status::SUCCESS
}

#[panic_handler]
fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     zfi::eprintln!("{info}");
     loop {}
}
```